### PR TITLE
Add support for rename

### DIFF
--- a/src/main/resources/META-INF/aop.xml
+++ b/src/main/resources/META-INF/aop.xml
@@ -19,17 +19,23 @@
 <aspectj>
           
    <aspects>
-       <!-- Configuration for Consistent Listing -->
+        <!-- Configuration for Consistent Listing --> 
         
-       <aspect name="com.netflix.bdp.s3mper.listing.ConsistentListingAspect"/>
-       <concrete-aspect name="com.netflix.bdp.s3mper.listing__ConsistentListing"
-                        extends="com.netflix.bdp.s3mper.listing.ConsistentListingAspect">
-           <pointcut name="init" expression="execution(* org.apache.hadoop.fs.FileSystem.initialize(..))"/>
-           <pointcut name="create" expression="execution(* org.apache.hadoop.fs.FileSystem.create(..)) ||
-                                                execution(* org.apache.hadoop.fs.FileSystem.mkdirs(..))"/>
-           <pointcut name="list" expression="execution(* org.apache.hadoop.fs.FileSystem.listStatus(..))"/>
-           <pointcut name="delete" expression="execution(* org.apache.hadoop.fs.FileSystem.delete(..))"/>
-       </concrete-aspect>
+        <aspect name="com.netflix.bdp.s3mper.listing.ConsistentListingAspect"/>
+        
+        <concrete-aspect name="com.netflix.bdp.s3mper.listing__ConsistentListing"
+                         extends="com.netflix.bdp.s3mper.listing.ConsistentListingAspect">
+            <pointcut name="init" expression="execution(* org.apache.hadoop..*NativeS3FileSystem.initialize(..)) ||
+                                              execution(* com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase.initialize(..))"/>
+            <pointcut name="create" expression="execution(* org.apache.hadoop..*NativeS3FileSystem.create(..)) ||
+                                                execution(* org.apache.hadoop..*NativeS3FileSystem.mkdirs(..)) ||
+                                                execution(* com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase.create(..)) ||
+                                                execution(* com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase.mkdirs(..))"/>
+            <pointcut name="list" expression="execution(* org.apache.hadoop..*NativeS3FileSystem.listStatus(..)) ||
+                                              execution(* com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase.listStatus(..))"/>
+            <pointcut name="delete" expression="execution(* org.apache.hadoop..*NativeS3FileSystem.listStatus(..)) ||
+                                                execution(* com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase.delete(..))"/>
+        </concrete-aspect>
 
    </aspects>
 

--- a/src/main/resources/META-INF/aop.xml
+++ b/src/main/resources/META-INF/aop.xml
@@ -35,6 +35,8 @@
                                               execution(* com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase.listStatus(..))"/>
             <pointcut name="delete" expression="execution(* org.apache.hadoop..*NativeS3FileSystem.listStatus(..)) ||
                                                 execution(* com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase.delete(..))"/>
+            <pointcut name="rename" expression="execution(* org.apache.hadoop..*NativeS3FileSystem.rename(..)) ||
+                                                execution(* com.google.cloud.hadoop.fs.gcs.GoogleHadoopFileSystemBase.rename(..))"/>
         </concrete-aspect>
 
    </aspects>


### PR DESCRIPTION
```
Implement rename by first duplicating the metadata for the destination,
then executing the rename and finally deleting the metadata for
the source location. This prevents incomplete listings for both,
the source and the destination as clients will fail or retry on
missing objects. In case of invalid operations, the rename
will return false and the duplicated metadata will be deleted again.
In case of errors, rename will throw Exceptions and the metadata
will not be cleaned up, thus preventing incomplete listings for both,
source and destination. Manual cleanup will be required in these
scenarios but preventing reading incomplete data is the most important
right now.
```
