### PR TITLE
Move required jars to build/libs during release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,7 +114,7 @@ task copyScripts(type: Copy) {
 
 task copyDeps(type: Copy) {
     from configurations.runtime 
-    includes = [ 'aspectjrt*', 'aspectjweaver*' ]     
+    includes = [ 'aspectjrt*', 'aspectjweaver*', '*hbase*' ]
     into tasks.jar.destinationDir
 }
 tasks.assemble.dependsOn(copyDeps)


### PR DESCRIPTION
Move all jars required to run it on Dataproc to build/libs. The rest is already included in Hadoop and I skipped them to avoid duplicated classes. We should check if version are OK.
